### PR TITLE
Support JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 by calling the command,
 
 - create `index.ts` in the same directory with opening file if needed
-- add `export * from ${fileName}` to `index.ts` with sorting lines if needed
+- add `export * from ${fileName}` to `index.ts` or `index.js` with sorting lines if needed
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "commands": [
       {
         "command": "extension.addCurrentFileExportationToIndex",
-        "title": "Add export declaration of current file to index.ts"
+        "title": "Add export declaration of current file to index.js or index.ts"
       }
     ]
   },

--- a/src/commands/add-current-file-exportation-to-index.ts
+++ b/src/commands/add-current-file-exportation-to-index.ts
@@ -11,8 +11,7 @@ import {
   getLines,
   writeFile,
 } from '../utils/file-manager'
-
-const INDEX_FILE_NAME = 'index.ts'
+import { getExtension } from '../utils/file-name'
 
 const getFilePath = (): string => {
   if (!fileIsOpened()) {
@@ -28,12 +27,14 @@ const getFilePath = (): string => {
 
 const getIndexPath = (filePath: string): string => {
   const dirPath = path.dirname(filePath)
-  return path.join(dirPath, INDEX_FILE_NAME)
+  const extension = getExtension(filePath).replace('x', '') // jsx -> js
+  return path.join(dirPath, `index.${extension}`)
 }
 
 const getExportationLine = (filePath: string): string => {
   const fileName = path.basename(filePath)
-  const fileNameWithoutExtension = fileName.match(/(.+)\..+/)[1]
+  const extension = getExtension(fileName)
+  const fileNameWithoutExtension = fileName.replace(`.${extension}`, '')
   return `export * from './${fileNameWithoutExtension}';`
 }
 
@@ -53,14 +54,15 @@ const writeLineAndSort = (filePath: string, line: string): void => {
 export const addCurrentFileExportationToIndex = () => {
   try {
     const filePath = getFilePath()
+
+    if (!filePath.match(/\.[jt]sx?$/)) {
+      throw new ApplicationError('The file is not JavaScipt or TypeScript.')
+    }
+
     const indexFilePath = getIndexPath(filePath)
 
     if (filePath === indexFilePath) {
-      throw new ApplicationError('The file is index.ts itself.')
-    }
-
-    if (!filePath.match(/\.tsx?$/)) {
-      throw new ApplicationError('The file is not TypeScript.')
+      throw new ApplicationError('The file is the index file itself.')
     }
 
     createFileIfNotExists(indexFilePath)

--- a/src/utils/file-name.ts
+++ b/src/utils/file-name.ts
@@ -1,0 +1,9 @@
+export const getExtension = (filePath: string): string | null => {
+  const match = filePath.match(/.*\.(.+)/)
+
+  if (!match) {
+    return null
+  }
+
+  return match[1]
+}


### PR DESCRIPTION
close #1 

Support JS.
Calling the command on `foo.js` adds `export * from './foo'` to `index.js`.

Someone may want to add `export * from './foo'` not to `index.js` but to `index.ts` (the phase where migrating from JS to TS), but for now, I supported the above case.